### PR TITLE
Fix registryIdRef

### DIFF
--- a/apis/project/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/project/v1alpha1/zz_generated.deepcopy.go
@@ -766,11 +766,6 @@ func (in *ProjectInitParameters) DeepCopyInto(out *ProjectInitParameters) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.RegistryID != nil {
-		in, out := &in.RegistryID, &out.RegistryID
-		*out = new(float64)
-		**out = **in
-	}
 	if in.StorageQuota != nil {
 		in, out := &in.StorageQuota, &out.StorageQuota
 		*out = new(float64)
@@ -954,6 +949,16 @@ func (in *ProjectParameters) DeepCopyInto(out *ProjectParameters) {
 		in, out := &in.RegistryID, &out.RegistryID
 		*out = new(float64)
 		**out = **in
+	}
+	if in.RegistryIDRef != nil {
+		in, out := &in.RegistryIDRef, &out.RegistryIDRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.RegistryIDSelector != nil {
+		in, out := &in.RegistryIDSelector, &out.RegistryIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.StorageQuota != nil {
 		in, out := &in.StorageQuota, &out.StorageQuota

--- a/apis/project/v1alpha1/zz_generated.resolvers.go
+++ b/apis/project/v1alpha1/zz_generated.resolvers.go
@@ -8,6 +8,8 @@ package v1alpha1
 import (
 	"context"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
+	v1alpha1 "github.com/globallogicuki/provider-harbor/apis/registry/v1alpha1"
+	common "github.com/globallogicuki/provider-harbor/config/common"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -86,6 +88,32 @@ func (mg *MemberUser) ResolveReferences(ctx context.Context, c client.Reader) er
 	}
 	mg.Spec.ForProvider.ProjectID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.ProjectIDRef = rsp.ResolvedReference
+
+	return nil
+}
+
+// ResolveReferences of this Project.
+func (mg *Project) ResolveReferences(ctx context.Context, c client.Reader) error {
+	r := reference.NewAPIResolver(c, mg)
+
+	var rsp reference.ResolutionResponse
+	var err error
+
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromFloatPtrValue(mg.Spec.ForProvider.RegistryID),
+		Extract:      common.ExtractRegistryId(),
+		Reference:    mg.Spec.ForProvider.RegistryIDRef,
+		Selector:     mg.Spec.ForProvider.RegistryIDSelector,
+		To: reference.To{
+			List:    &v1alpha1.RegistryList{},
+			Managed: &v1alpha1.Registry{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.RegistryID")
+	}
+	mg.Spec.ForProvider.RegistryID = reference.ToFloatPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.RegistryIDRef = rsp.ResolvedReference
 
 	return nil
 }

--- a/apis/project/v1alpha1/zz_project_types.go
+++ b/apis/project/v1alpha1/zz_project_types.go
@@ -40,9 +40,6 @@ type ProjectInitParameters struct {
 	// (Boolean) The project will be public accessibility.(Default: false)
 	Public *bool `json:"public,omitempty" tf:"public,omitempty"`
 
-	// (Number) To enable project as Proxy Cache.
-	RegistryID *float64 `json:"registryId,omitempty" tf:"registry_id,omitempty"`
-
 	// (Number) The storage quota of the project in GB's.
 	StorageQuota *float64 `json:"storageQuota,omitempty" tf:"storage_quota,omitempty"`
 
@@ -120,8 +117,18 @@ type ProjectParameters struct {
 	Public *bool `json:"public,omitempty" tf:"public,omitempty"`
 
 	// (Number) To enable project as Proxy Cache.
+	// +crossplane:generate:reference:type=github.com/globallogicuki/provider-harbor/apis/registry/v1alpha1.Registry
+	// +crossplane:generate:reference:extractor=github.com/globallogicuki/provider-harbor/config/common.ExtractRegistryId()
 	// +kubebuilder:validation:Optional
 	RegistryID *float64 `json:"registryId,omitempty" tf:"registry_id,omitempty"`
+
+	// Reference to a Registry in registry to populate registryId.
+	// +kubebuilder:validation:Optional
+	RegistryIDRef *v1.Reference `json:"registryIdRef,omitempty" tf:"-"`
+
+	// Selector for a Registry in registry to populate registryId.
+	// +kubebuilder:validation:Optional
+	RegistryIDSelector *v1.Selector `json:"registryIdSelector,omitempty" tf:"-"`
 
 	// (Number) The storage quota of the project in GB's.
 	// +kubebuilder:validation:Optional

--- a/apis/registry/v1alpha1/zz_generated.resolvers.go
+++ b/apis/registry/v1alpha1/zz_generated.resolvers.go
@@ -8,6 +8,7 @@ package v1alpha1
 import (
 	"context"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
+	common "github.com/globallogicuki/provider-harbor/config/common"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -21,7 +22,7 @@ func (mg *Replication) ResolveReferences(ctx context.Context, c client.Reader) e
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromFloatPtrValue(mg.Spec.ForProvider.RegistryID),
-		Extract:      reference.ExternalName(),
+		Extract:      common.ExtractRegistryId(),
 		Reference:    mg.Spec.ForProvider.RegistryIDRef,
 		Selector:     mg.Spec.ForProvider.RegistryIDSelector,
 		To: reference.To{

--- a/apis/registry/v1alpha1/zz_replication_types.go
+++ b/apis/registry/v1alpha1/zz_replication_types.go
@@ -207,6 +207,7 @@ type ReplicationParameters struct {
 
 	// (Number) The registry ID of the Registry Endpoint.
 	// +crossplane:generate:reference:type=github.com/globallogicuki/provider-harbor/apis/registry/v1alpha1.Registry
+	// +crossplane:generate:reference:extractor=github.com/globallogicuki/provider-harbor/config/common.ExtractRegistryId()
 	// +kubebuilder:validation:Optional
 	RegistryID *float64 `json:"registryId,omitempty" tf:"registry_id,omitempty"`
 

--- a/config/common/common.go
+++ b/config/common/common.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"github.com/crossplane/crossplane-runtime/pkg/reference"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+)
+
+const (
+	// SelfPackagePath is the golang path for this package.
+	SelfPackagePath = "github.com/globallogicuki/provider-harbor/config/common"
+
+	// AccessorExtractor is the golang path to ExtractAccessor function
+	// in this package.
+	RegistryIdExtractor = SelfPackagePath + ".ExtractRegistryId()" 
+)
+
+// ExtractRegistryId extracts the registryId parameter from a registry object
+func ExtractRegistryId() reference.ExtractValueFn {
+    return func(mg resource.Managed) string {
+        paved, err := fieldpath.PaveObject(mg)
+        if err != nil {
+            return ""
+        }
+        r, err := paved.GetValue("status.atProvider.registryId")
+        if err != nil {
+            return ""
+        }
+		// Convert the interface{} to a string based on its actual type, we expect a float64!
+        switch v := r.(type) {
+        case float64:
+            return strconv.FormatFloat(v, 'f', -1, 64)
+        default:
+            fmt.Printf("unsupported type: %T\n", v)
+            return ""
+        }
+    }
+}

--- a/config/common/common.go
+++ b/config/common/common.go
@@ -29,29 +29,29 @@ const (
 	// SelfPackagePath is the golang path for this package.
 	SelfPackagePath = "github.com/globallogicuki/provider-harbor/config/common"
 
-	// AccessorExtractor is the golang path to ExtractAccessor function
+	// RegistryIdExtractor is the golang path to ExtractAccessor function
 	// in this package.
-	RegistryIdExtractor = SelfPackagePath + ".ExtractRegistryId()" 
+	RegistryIdExtractor = SelfPackagePath + ".ExtractRegistryId()"
 )
 
 // ExtractRegistryId extracts the registryId parameter from a registry object
 func ExtractRegistryId() reference.ExtractValueFn {
-    return func(mg resource.Managed) string {
-        paved, err := fieldpath.PaveObject(mg)
-        if err != nil {
-            return ""
-        }
-        r, err := paved.GetValue("status.atProvider.registryId")
-        if err != nil {
-            return ""
-        }
+	return func(mg resource.Managed) string {
+		paved, err := fieldpath.PaveObject(mg)
+		if err != nil {
+			return ""
+		}
+		r, err := paved.GetValue("status.atProvider.registryId")
+		if err != nil {
+			return ""
+		}
 		// Convert the interface{} to a string based on its actual type, we expect a float64!
-        switch v := r.(type) {
-        case float64:
-            return strconv.FormatFloat(v, 'f', -1, 64)
-        default:
-            fmt.Printf("unsupported type: %T\n", v)
-            return ""
-        }
-    }
+		switch v := r.(type) {
+		case float64:
+			return strconv.FormatFloat(v, 'f', -1, 64)
+		default:
+			fmt.Printf("unsupported type: %T\n", v)
+			return ""
+		}
+	}
 }

--- a/config/project/config.go
+++ b/config/project/config.go
@@ -14,7 +14,7 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "project"
 		r.Kind = "Project"
 		r.References["registry_id"] = config.Reference{
-			Type: "github.com/globallogicuki/provider-harbor/apis/registry/v1alpha1.Registry",
+			Type:      "github.com/globallogicuki/provider-harbor/apis/registry/v1alpha1.Registry",
 			Extractor: common.RegistryIdExtractor,
 		}
 	})

--- a/config/project/config.go
+++ b/config/project/config.go
@@ -1,10 +1,21 @@
 package project
 
-import "github.com/crossplane/upjet/pkg/config"
+import (
+	"github.com/crossplane/upjet/pkg/config"
+	"github.com/globallogicuki/provider-harbor/config/common"
+)
 
 // Configure harbor_project resource
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("harbor_project", func(r *config.Resource) {
 		r.ShortGroup = "project"
+	})
+	p.AddResourceConfigurator("harbor_project", func(r *config.Resource) {
+		r.ShortGroup = "project"
+		r.Kind = "Project"
+		r.References["registry_id"] = config.Reference{
+			Type: "github.com/globallogicuki/provider-harbor/apis/registry/v1alpha1.Registry",
+			Extractor: common.RegistryIdExtractor,
+		}
 	})
 }

--- a/config/replication/config.go
+++ b/config/replication/config.go
@@ -1,6 +1,9 @@
 package replication
 
-import "github.com/crossplane/upjet/pkg/config"
+import (
+	"github.com/crossplane/upjet/pkg/config"
+	"github.com/globallogicuki/provider-harbor/config/common"
+)
 
 // Configure harbor_replication resource
 func Configure(p *config.Provider) {
@@ -9,6 +12,7 @@ func Configure(p *config.Provider) {
 		r.Kind = "Replication"
 		r.References["registry_id"] = config.Reference{
 			Type: "github.com/globallogicuki/provider-harbor/apis/registry/v1alpha1.Registry",
+			Extractor: common.RegistryIdExtractor,
 		}
 	})
 }

--- a/config/replication/config.go
+++ b/config/replication/config.go
@@ -11,7 +11,7 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "registry"
 		r.Kind = "Replication"
 		r.References["registry_id"] = config.Reference{
-			Type: "github.com/globallogicuki/provider-harbor/apis/registry/v1alpha1.Registry",
+			Type:      "github.com/globallogicuki/provider-harbor/apis/registry/v1alpha1.Registry",
 			Extractor: common.RegistryIdExtractor,
 		}
 	})

--- a/package/crds/project.harbor.crossplane.io_projects.yaml
+++ b/package/crds/project.harbor.crossplane.io_projects.yaml
@@ -99,6 +99,79 @@ spec:
                   registryId:
                     description: (Number) To enable project as Proxy Cache.
                     type: number
+                  registryIdRef:
+                    description: Reference to a Registry in registry to populate registryId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  registryIdSelector:
+                    description: Selector for a Registry in registry to populate registryId.
+                    properties:
+                      matchControllerRef:
+                        description: MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   storageQuota:
                     description: (Number) The storage quota of the project in GB's.
                     type: number
@@ -149,9 +222,6 @@ spec:
                     description: '(Boolean) The project will be public accessibility.(Default:
                       false)'
                     type: boolean
-                  registryId:
-                    description: (Number) To enable project as Proxy Cache.
-                    type: number
                   storageQuota:
                     description: (Number) The storage quota of the project in GB's.
                     type: number


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This pull request fixes the registryIdRef for Replication object by adding a custom extractor function to fetch the "registryId" parameter of a Registry object. Additionally, this pull request adds an option to the Project resource to create cache proxy projects by supplying the registryId parameter also via registryIdRef.

Fixes #4

I have:

- [X] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

The provider has been tested locally as described in #4. Results from the test can also be found there.

[contribution process]: https://git.io/fj2m9
