### PR TITLE
fix external secret stores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ submodules:
 run: go.build
 	@$(INFO) Running Crossplane locally out-of-cluster . . .
 	@# To see other arguments that can be provided, run the command with --help instead
-	UPBOUND_CONTEXT="local" $(GO_OUT_DIR)/provider --debug --enable-external-secret-stores
+	UPBOUND_CONTEXT="local" $(GO_OUT_DIR)/provider --debug
 
 # ====================================================================================
 # End to End Testing

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ submodules:
 run: go.build
 	@$(INFO) Running Crossplane locally out-of-cluster . . .
 	@# To see other arguments that can be provided, run the command with --help instead
-	UPBOUND_CONTEXT="local" $(GO_OUT_DIR)/provider --debug
+	UPBOUND_CONTEXT="local" $(GO_OUT_DIR)/provider --debug --enable-external-secret-stores
 
 # ====================================================================================
 # End to End Testing

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/certificates"
 	xpcontroller "github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -49,6 +50,7 @@ func main() {
 
 		namespace                  = app.Flag("namespace", "Namespace used to set as default scope in default secret store config.").Default("crossplane-system").Envar("POD_NAMESPACE").String()
 		enableExternalSecretStores = app.Flag("enable-external-secret-stores", "Enable support for ExternalSecretStores.").Default("false").Envar("ENABLE_EXTERNAL_SECRET_STORES").Bool()
+		essTLSCertsPath            = app.Flag("ess-tls-cert-dir", "Path of ESS TLS certificates.").Envar("ESS_TLS_CERTS_DIR").String()
 		enableManagementPolicies   = app.Flag("enable-management-policies", "Enable support for Management Policies.").Default("true").Envar("ENABLE_MANAGEMENT_POLICIES").Bool()
 	)
 
@@ -98,6 +100,14 @@ func main() {
 	if *enableExternalSecretStores {
 		o.SecretStoreConfigGVK = &v1alpha1.StoreConfigGroupVersionKind
 		log.Info("Alpha feature enabled", "flag", features.EnableAlphaExternalSecretStores)
+		o.ESSOptions = &tjcontroller.ESSOptions{}
+		if *essTLSCertsPath != "" {
+			log.Info("ESS TLS certificates path is set. Loading mTLS configuration.")
+			tCfg, err := certificates.LoadMTLSConfig(filepath.Join(*essTLSCertsPath, "ca.crt"), filepath.Join(*essTLSCertsPath, "tls.crt"), filepath.Join(*essTLSCertsPath, "tls.key"), false)
+			kingpin.FatalIfError(err, "Cannot load ESS TLS config.")
+
+			o.ESSOptions.TLSConfig = tCfg
+		}
 
 		// Ensure default store config exists.
 		kingpin.FatalIfError(resource.Ignore(kerrors.IsAlreadyExists, mgr.GetClient().Create(context.Background(), &v1alpha1.StoreConfig{

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -4,19 +4,17 @@
 
 package features
 
-import (
-	xpfeature "github.com/crossplane/crossplane-runtime/pkg/feature"
-)
+import "github.com/crossplane/crossplane-runtime/pkg/feature"
 
 // Feature flags.
 const (
 	// EnableAlphaExternalSecretStores enables alpha support for
 	// External Secret Stores. See the below design for more details.
 	// https://github.com/crossplane/crossplane/blob/390ddd/design/design-doc-external-secret-stores.md
-	EnableAlphaExternalSecretStores xpfeature.Flag = "EnableAlphaExternalSecretStores"
+	EnableAlphaExternalSecretStores feature.Flag = "EnableAlphaExternalSecretStores"
 
 	// EnableBetaManagementPolicies enables beta support for
 	// Management Policies. See the below design for more details.
 	// https://github.com/crossplane/crossplane/pull/3531
-	EnableBetaManagementPolicies xpfeature.Flag = xpfeature.EnableBetaManagementPolicies
+	EnableBetaManagementPolicies feature.Flag = "EnableBetaManagementPolicies"
 )


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This pull request addresses the issue of enabling the external secret stores plugin for the harbor provider. This was a [known issue](https://github.com/upbound/provider-vault/commit/ada92eb33257187cbfd71ee0389ceeb40c10ccae#diff-36b6d20eb5aea66cf39f8d94111bd96513626ef7f61459f0d9e8e9507ded1d17). I have applied the same configuration changes as in the linked issue.

Fixes #6

I have:

- [X] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I have added the --enable-external-secret-stores flag to the "make run" command to enable the external secret stores feature when the provider is run locally. Then I used the provider locally to provision a robot account in Harbor where the generated secret is stored to a Kubernetes secret using the "default" StoreConfig. 

![Screenshot 2024-07-25 at 12 19 55](https://github.com/user-attachments/assets/3c270c70-7d09-401b-b044-e482948ba49f)

[contribution process]: https://git.io/fj2m9
