### PR TITLE
Fix RobotAccount CRUD from robot account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@
 PROJECT_NAME ?= provider-harbor
 PROJECT_REPO ?= github.com/globallogicuki/$(PROJECT_NAME)
 
-export TERRAFORM_VERSION ?= 1.7.5
+export TERRAFORM_VERSION ?= 1.10.5
 
 export TERRAFORM_PROVIDER_SOURCE ?= goharbor/harbor
 export TERRAFORM_PROVIDER_REPO ?= https://github.com/goharbor/terraform-provider-harbor
-export TERRAFORM_PROVIDER_VERSION ?= 3.10.10
+export TERRAFORM_PROVIDER_VERSION ?= 3.10.19
 export TERRAFORM_PROVIDER_DOWNLOAD_NAME ?= terraform-provider-harbor
 export TERRAFORM_PROVIDER_DOWNLOAD_URL_PREFIX ?= $(TERRAFORM_PROVIDER_REPO)/releases/download/v$(TERRAFORM_PROVIDER_VERSION)/
 export TERRAFORM_NATIVE_PROVIDER_BINARY ?= terraform-provider-harbor_v$(TERRAFORM_PROVIDER_VERSION)
@@ -58,17 +58,17 @@ UPTEST_VERSION = v0.5.0
 # ====================================================================================
 # Setup Images
 
-REGISTRY_ORGS ?= xpkg.upbound.io/globallogicuki
+REGISTRY_ORGS ?= registry-docker.apps.eul.sncf.fr/sandbox
 IMAGES = $(PROJECT_NAME)
 -include build/makelib/imagelight.mk
 
 # ====================================================================================
 # Setup XPKG
 
-XPKG_REG_ORGS ?= xpkg.upbound.io/globallogicuki
+XPKG_REG_ORGS ?= registry-docker.apps.eul.sncf.fr/sandbox
 # NOTE(hasheddan): skip promoting on xpkg.upbound.io as channel tags are
 # inferred.
-XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/globallogicuki
+XPKG_REG_ORGS_NO_PROMOTE ?= registry-docker.apps.eul.sncf.fr/sandbox
 XPKGS = $(PROJECT_NAME)
 -include build/makelib/xpkg.mk
 

--- a/internal/clients/harbor.go
+++ b/internal/clients/harbor.go
@@ -29,6 +29,7 @@ const (
 	url         = "url"
 	username    = "username"
 	password    = "password"
+	robotPrefix    = "robot_prefix"
 	apiVersion  = "api_version"
 	bearerToken = "bearer_token"
 	insecure    = "insecure"
@@ -38,6 +39,8 @@ type harborConfig struct {
 	URL         *string `json:"url,omitempty"`
 	Username    *string `json:"username,omitempty"`
 	Password    *string `json:"password,omitempty"`
+	// robot_prefix is an optional field that specifies the prefix for robot account names in Harbor.
+	RobotPrefix    *string `json:"robot_prefix,omitempty"`
 	APIVersion  *int    `json:"api_version,omitempty"`
 	BearerToken *string `json:"bearer_token,omitempty"`
 	Insecure    *bool   `json:"insecure,omitempty"`
@@ -52,6 +55,10 @@ func terraformProviderConfigurationBuilder(creds harborConfig) terraform.Provide
 
 	if creds.Username != nil {
 		cnf[username] = *creds.Username
+	}
+
+	if creds.RobotPrefix != nil {
+		cnf[robotPrefix] = *creds.RobotPrefix
 	}
 
 	if creds.Password != nil {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

- Upgraded Terraform provider from version 3.10.10 to 3.10.19.
- Added a new property to harborConfig to enforce the use of credentials with a robot account instead of the admin user.

Fixes #

You cannot create a robot account using another robot account.

I have:

- [ x ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
