### PR TITLE
Refactor to TerraformName from deprecated Type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,12 @@ jobs:
 
       - name: Get modified CRDs
         id: modified-crds
-        uses: tj-actions/changed-files@v45
-        with:
-          files: |
-            package/crds/**
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=1
+          MODIFIED_CRD_LIST=$(git diff --name-only origin/${{ github.base_ref }} HEAD -- package/crds/)
+          echo "::set-output name=any_changed::$( [ -n \"$MODIFIED_CRD_LIST\" ] && echo 'true' || echo 'false' )"
+          echo "::set-output name=all_changed_files::$MODIFIED_CRD_LIST"
+        shell: bash
       - name: Report breaking CRD OpenAPI v3 schema changes
         if: steps.modified-crds.outputs.any_changed == 'true'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,10 @@ jobs:
 
       - name: Get modified CRDs
         id: modified-crds
-        run: |
-          git fetch origin ${{ github.base_ref }} --depth=1
-          MODIFIED_CRD_LIST=$(git diff --name-only origin/${{ github.base_ref }} HEAD -- package/crds/)
-          echo "::set-output name=any_changed::$( [ -n \"$MODIFIED_CRD_LIST\" ] && echo 'true' || echo 'false' )"
-          echo "::set-output name=all_changed_files::$MODIFIED_CRD_LIST"
-        shell: bash
+        uses: tj-actions/changed-files@v46.0.1
+        with:
+          files: |
+            package/crds/**
       - name: Report breaking CRD OpenAPI v3 schema changes
         if: steps.modified-crds.outputs.any_changed == 'true'
         env:

--- a/config/immutabletagrule/config.go
+++ b/config/immutabletagrule/config.go
@@ -8,7 +8,7 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "project"
 		r.Kind = "ImmutableTagRule"
 		r.References["project_id"] = config.Reference{
-			Type: "github.com/globallogicuki/provider-harbor/apis/project/v1alpha1.Project",
+			TerraformName: "harbor_project",
 		}
 	})
 }

--- a/config/label/config.go
+++ b/config/label/config.go
@@ -7,7 +7,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("harbor_label", func(r *config.Resource) {
 		r.ShortGroup = "label"
 		r.References["project_id"] = config.Reference{
-			Type: "github.com/globallogicuki/provider-harbor/apis/project/v1alpha1.Project",
+			TerraformName: "harbor_project",
 		}
 	})
 }

--- a/config/membergroup/config.go
+++ b/config/membergroup/config.go
@@ -8,7 +8,7 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "project"
 		r.Kind = "MemberGroup"
 		r.References["project_id"] = config.Reference{
-			Type: "github.com/globallogicuki/provider-harbor/apis/project/v1alpha1.Project",
+			TerraformName: "harbor_project",
 		}
 	})
 }

--- a/config/memberuser/config.go
+++ b/config/memberuser/config.go
@@ -8,7 +8,7 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "project"
 		r.Kind = "MemberUser"
 		r.References["project_id"] = config.Reference{
-			Type: "github.com/globallogicuki/provider-harbor/apis/project/v1alpha1.Project",
+			TerraformName: "harbor_project",
 		}
 	})
 }

--- a/config/project/config.go
+++ b/config/project/config.go
@@ -14,8 +14,8 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "project"
 		r.Kind = "Project"
 		r.References["registry_id"] = config.Reference{
-			Type:      "github.com/globallogicuki/provider-harbor/apis/registry/v1alpha1.Registry",
-			Extractor: common.RegistryIDExtractor,
+			TerraformName: "harbor_registry",
+			Extractor:     common.RegistryIDExtractor,
 		}
 	})
 }

--- a/config/replication/config.go
+++ b/config/replication/config.go
@@ -11,8 +11,8 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "registry"
 		r.Kind = "Replication"
 		r.References["registry_id"] = config.Reference{
-			Type:      "github.com/globallogicuki/provider-harbor/apis/registry/v1alpha1.Registry",
-			Extractor: common.RegistryIDExtractor,
+			TerraformName: "harbor_registry",
+			Extractor:     common.RegistryIDExtractor,
 		}
 	})
 }

--- a/config/retentionpolicy/config.go
+++ b/config/retentionpolicy/config.go
@@ -8,7 +8,7 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "project"
 		r.Kind = "RetentionPolicy"
 		r.References["scope"] = config.Reference{
-			Type: "github.com/globallogicuki/provider-harbor/apis/project/v1alpha1.Project",
+			TerraformName: "harbor_project",
 		}
 	})
 }

--- a/config/webhook/config.go
+++ b/config/webhook/config.go
@@ -8,7 +8,7 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "project"
 		r.Kind = "Webhook"
 		r.References["project_id"] = config.Reference{
-			Type: "github.com/globallogicuki/provider-harbor/apis/project/v1alpha1.Project",
+			TerraformName: "harbor_project",
 		}
 	})
 }


### PR DESCRIPTION
As [per the Upjet docs](https://arc.net/l/quote/xgmfxpah), Type is deprecated in favour of the more stable TerraformName refererence.

`make generate` was run and validated no CRD changes. Purely an upgrade.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.