### PR TITLE
fix: Clarify usage of doublestar pattern for string matching in docs

### DIFF
--- a/apis/project/v1alpha1/zz_immutabletagrule_types.go
+++ b/apis/project/v1alpha1/zz_immutabletagrule_types.go
@@ -23,15 +23,19 @@ type ImmutableTagRuleInitParameters struct {
 	Disabled *bool `json:"disabled,omitempty" tf:"disabled,omitempty"`
 
 	// (String) For the repositories excluding.
+	// Use doublestar pattern for path matching.
 	RepoExcluding *string `json:"repoExcluding,omitempty" tf:"repo_excluding,omitempty"`
 
 	// (String) For the repositories matching.
+	// Use doublestar pattern for path matching.
 	RepoMatching *string `json:"repoMatching,omitempty" tf:"repo_matching,omitempty"`
 
 	// (String) For the tag excluding.
+	// Use doublestar pattern for path matching.
 	TagExcluding *string `json:"tagExcluding,omitempty" tf:"tag_excluding,omitempty"`
 
 	// (String) For the tag matching.
+	// Use doublestar pattern for path matching.
 	TagMatching *string `json:"tagMatching,omitempty" tf:"tag_matching,omitempty"`
 }
 
@@ -47,15 +51,19 @@ type ImmutableTagRuleObservation struct {
 	ProjectID *string `json:"projectId,omitempty" tf:"project_id,omitempty"`
 
 	// (String) For the repositories excluding.
+	// Use doublestar pattern for path matching.
 	RepoExcluding *string `json:"repoExcluding,omitempty" tf:"repo_excluding,omitempty"`
 
 	// (String) For the repositories matching.
+	// Use doublestar pattern for path matching.
 	RepoMatching *string `json:"repoMatching,omitempty" tf:"repo_matching,omitempty"`
 
 	// (String) For the tag excluding.
+	// Use doublestar pattern for path matching.
 	TagExcluding *string `json:"tagExcluding,omitempty" tf:"tag_excluding,omitempty"`
 
 	// (String) For the tag matching.
+	// Use doublestar pattern for path matching.
 	TagMatching *string `json:"tagMatching,omitempty" tf:"tag_matching,omitempty"`
 }
 
@@ -79,18 +87,22 @@ type ImmutableTagRuleParameters struct {
 	ProjectIDSelector *v1.Selector `json:"projectIdSelector,omitempty" tf:"-"`
 
 	// (String) For the repositories excluding.
+	// Use doublestar pattern for path matching.
 	// +kubebuilder:validation:Optional
 	RepoExcluding *string `json:"repoExcluding,omitempty" tf:"repo_excluding,omitempty"`
 
 	// (String) For the repositories matching.
+	// Use doublestar pattern for path matching.
 	// +kubebuilder:validation:Optional
 	RepoMatching *string `json:"repoMatching,omitempty" tf:"repo_matching,omitempty"`
 
 	// (String) For the tag excluding.
+	// Use doublestar pattern for path matching.
 	// +kubebuilder:validation:Optional
 	TagExcluding *string `json:"tagExcluding,omitempty" tf:"tag_excluding,omitempty"`
 
 	// (String) For the tag matching.
+	// Use doublestar pattern for path matching.
 	// +kubebuilder:validation:Optional
 	TagMatching *string `json:"tagMatching,omitempty" tf:"tag_matching,omitempty"`
 }

--- a/apis/project/v1alpha1/zz_retentionpolicy_types.go
+++ b/apis/project/v1alpha1/zz_retentionpolicy_types.go
@@ -86,15 +86,19 @@ type RuleInitParameters struct {
 	NDaysSinceLastPush *float64 `json:"nDaysSinceLastPush,omitempty" tf:"n_days_since_last_push,omitempty"`
 
 	// (String) For the repositories excluding.
+	// Use doublestar pattern for path matching.
 	RepoExcluding *string `json:"repoExcluding,omitempty" tf:"repo_excluding,omitempty"`
 
 	// (String) For the repositories matching.
+	// Use doublestar pattern for path matching.
 	RepoMatching *string `json:"repoMatching,omitempty" tf:"repo_matching,omitempty"`
 
 	// (String) For the tag excluding.
+	// Use doublestar pattern for path matching.
 	TagExcluding *string `json:"tagExcluding,omitempty" tf:"tag_excluding,omitempty"`
 
 	// (String) For the tag matching.
+	// Use doublestar pattern for path matching.
 	TagMatching *string `json:"tagMatching,omitempty" tf:"tag_matching,omitempty"`
 
 	// (Boolean) with untagged artifacts. Defaults to true
@@ -122,15 +126,19 @@ type RuleObservation struct {
 	NDaysSinceLastPush *float64 `json:"nDaysSinceLastPush,omitempty" tf:"n_days_since_last_push,omitempty"`
 
 	// (String) For the repositories excluding.
+	// Use doublestar pattern for path matching.
 	RepoExcluding *string `json:"repoExcluding,omitempty" tf:"repo_excluding,omitempty"`
 
 	// (String) For the repositories matching.
+	// Use doublestar pattern for path matching.
 	RepoMatching *string `json:"repoMatching,omitempty" tf:"repo_matching,omitempty"`
 
 	// (String) For the tag excluding.
+	// Use doublestar pattern for path matching.
 	TagExcluding *string `json:"tagExcluding,omitempty" tf:"tag_excluding,omitempty"`
 
 	// (String) For the tag matching.
+	// Use doublestar pattern for path matching.
 	TagMatching *string `json:"tagMatching,omitempty" tf:"tag_matching,omitempty"`
 
 	// (Boolean) with untagged artifacts. Defaults to true
@@ -164,18 +172,22 @@ type RuleParameters struct {
 	NDaysSinceLastPush *float64 `json:"nDaysSinceLastPush,omitempty" tf:"n_days_since_last_push,omitempty"`
 
 	// (String) For the repositories excluding.
+	// Use doublestar pattern for path matching.
 	// +kubebuilder:validation:Optional
 	RepoExcluding *string `json:"repoExcluding,omitempty" tf:"repo_excluding,omitempty"`
 
 	// (String) For the repositories matching.
+	// Use doublestar pattern for path matching.
 	// +kubebuilder:validation:Optional
 	RepoMatching *string `json:"repoMatching,omitempty" tf:"repo_matching,omitempty"`
 
 	// (String) For the tag excluding.
+	// Use doublestar pattern for path matching.
 	// +kubebuilder:validation:Optional
 	TagExcluding *string `json:"tagExcluding,omitempty" tf:"tag_excluding,omitempty"`
 
 	// (String) For the tag matching.
+	// Use doublestar pattern for path matching.
 	// +kubebuilder:validation:Optional
 	TagMatching *string `json:"tagMatching,omitempty" tf:"tag_matching,omitempty"`
 

--- a/config/immutabletagrule/config.go
+++ b/config/immutabletagrule/config.go
@@ -1,6 +1,10 @@
 package immutabletagrule
 
-import "github.com/crossplane/upjet/pkg/config"
+import (
+	"strings"
+
+	"github.com/crossplane/upjet/pkg/config"
+)
 
 // Configure harbor_immutable_tag_rule resource
 func Configure(p *config.Provider) {
@@ -9,6 +13,13 @@ func Configure(p *config.Provider) {
 		r.Kind = "ImmutableTagRule"
 		r.References["project_id"] = config.Reference{
 			TerraformName: "harbor_project",
+		}
+
+		// Update any matching or excluding fields to improve the Terraform documentation
+		for fieldName, s := range r.TerraformResource.Schema {
+			if strings.Contains(fieldName, "_excluding") || strings.Contains(fieldName, "_matching") {
+				s.Description = "Use doublestar pattern for path matching."
+			}
 		}
 	})
 }

--- a/config/retentionpolicy/config.go
+++ b/config/retentionpolicy/config.go
@@ -1,6 +1,11 @@
 package retentionpolicy
 
-import "github.com/crossplane/upjet/pkg/config"
+import (
+	"strings"
+
+	"github.com/crossplane/upjet/pkg/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
 
 // Configure harbor_retention_policy resource
 func Configure(p *config.Provider) {
@@ -10,5 +15,25 @@ func Configure(p *config.Provider) {
 		r.References["scope"] = config.Reference{
 			TerraformName: "harbor_project",
 		}
+
+		// Update any matching or excluding fields to improve the Terraform documentation
+		updateMatchingFieldDescriptions(r.TerraformResource.Schema)
 	})
+}
+
+// updateMatchingFieldDescriptions recursively updates the descriptions of all fields
+// with names containing "_excluding" or "_matching" at any nesting level
+func updateMatchingFieldDescriptions(schemaMap map[string]*schema.Schema) {
+	for fieldName, s := range schemaMap {
+		// Check if the current field name matches our criteria
+		if strings.Contains(fieldName, "_excluding") || strings.Contains(fieldName, "_matching") {
+			s.Description = "Use doublestar pattern for path matching."
+		}
+
+		// Check for nested fields in TypeList, TypeSet, or TypeMap with Elem as *schema.Resource
+		if elem, ok := s.Elem.(*schema.Resource); ok && elem != nil {
+			// Recursive call for nested fields
+			updateMatchingFieldDescriptions(elem.Schema)
+		}
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/crossplane/crossplane-runtime v1.14.0-rc.0.0.20231011070344-cc691421c2e5
 	github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79
 	github.com/crossplane/upjet v0.11.0-rc.0.0.20231012093706-c4a76d2a7505
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
 	github.com/pkg/errors v0.9.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/apimachinery v0.28.2
@@ -56,7 +57,6 @@ require (
 	github.com/hashicorp/terraform-json v0.14.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.14.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.7.0 // indirect
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0 // indirect
 	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/package/crds/project.harbor.crossplane.io_immutabletagrules.yaml
+++ b/package/crds/project.harbor.crossplane.io_immutabletagrules.yaml
@@ -148,16 +148,16 @@ spec:
                         type: object
                     type: object
                   repoExcluding:
-                    description: (String) For the repositories excluding.
+                    description: (String) For the repositories excluding, using doublestar pattern.
                     type: string
                   repoMatching:
-                    description: (String) For the repositories matching.
+                    description: (String) For the repositories matching, using doublestar pattern..
                     type: string
                   tagExcluding:
-                    description: (String) For the tag excluding.
+                    description: (String) For the tags excluding, using doublestar pattern.
                     type: string
                   tagMatching:
-                    description: (String) For the tag matching.
+                    description: (String) For the tags matching, using doublestar pattern.
                     type: string
                 type: object
               initProvider:
@@ -177,16 +177,16 @@ spec:
                       Defaults to false
                     type: boolean
                   repoExcluding:
-                    description: (String) For the repositories excluding.
+                    description: (String) For the repositories excluding, using doublestar pattern.
                     type: string
                   repoMatching:
-                    description: (String) For the repositories matching.
+                    description: (String) For the repositories matching, using doublestar pattern..
                     type: string
                   tagExcluding:
-                    description: (String) For the tag excluding.
+                    description: (String) For the tags excluding, using doublestar pattern.
                     type: string
                   tagMatching:
-                    description: (String) For the tag matching.
+                    description: (String) For the tags matching, using doublestar pattern.
                     type: string
                 type: object
               managementPolicies:
@@ -366,16 +366,16 @@ spec:
                       apply this policy.
                     type: string
                   repoExcluding:
-                    description: (String) For the repositories excluding.
+                    description: (String) For the repositories excluding, using doublestar pattern.
                     type: string
                   repoMatching:
-                    description: (String) For the repositories matching.
+                    description: (String) For the repositories matching, using doublestar pattern..
                     type: string
                   tagExcluding:
-                    description: (String) For the tag excluding.
+                    description: (String) For the tags excluding, using doublestar pattern.
                     type: string
                   tagMatching:
-                    description: (String) For the tag matching.
+                    description: (String) For the tags matching, using doublestar pattern.
                     type: string
                 type: object
               conditions:

--- a/package/crds/project.harbor.crossplane.io_immutabletagrules.yaml
+++ b/package/crds/project.harbor.crossplane.io_immutabletagrules.yaml
@@ -148,16 +148,20 @@ spec:
                         type: object
                     type: object
                   repoExcluding:
-                    description: (String) For the repositories excluding, using doublestar pattern.
+                    description: (String) For the repositories excluding. Use doublestar
+                      pattern for path matching.
                     type: string
                   repoMatching:
-                    description: (String) For the repositories matching, using doublestar pattern..
+                    description: (String) For the repositories matching. Use doublestar
+                      pattern for path matching.
                     type: string
                   tagExcluding:
-                    description: (String) For the tags excluding, using doublestar pattern.
+                    description: (String) For the tag excluding. Use doublestar pattern
+                      for path matching.
                     type: string
                   tagMatching:
-                    description: (String) For the tags matching, using doublestar pattern.
+                    description: (String) For the tag matching. Use doublestar pattern
+                      for path matching.
                     type: string
                 type: object
               initProvider:
@@ -177,16 +181,20 @@ spec:
                       Defaults to false
                     type: boolean
                   repoExcluding:
-                    description: (String) For the repositories excluding, using doublestar pattern.
+                    description: (String) For the repositories excluding. Use doublestar
+                      pattern for path matching.
                     type: string
                   repoMatching:
-                    description: (String) For the repositories matching, using doublestar pattern..
+                    description: (String) For the repositories matching. Use doublestar
+                      pattern for path matching.
                     type: string
                   tagExcluding:
-                    description: (String) For the tags excluding, using doublestar pattern.
+                    description: (String) For the tag excluding. Use doublestar pattern
+                      for path matching.
                     type: string
                   tagMatching:
-                    description: (String) For the tags matching, using doublestar pattern.
+                    description: (String) For the tag matching. Use doublestar pattern
+                      for path matching.
                     type: string
                 type: object
               managementPolicies:
@@ -366,16 +374,20 @@ spec:
                       apply this policy.
                     type: string
                   repoExcluding:
-                    description: (String) For the repositories excluding, using doublestar pattern.
+                    description: (String) For the repositories excluding. Use doublestar
+                      pattern for path matching.
                     type: string
                   repoMatching:
-                    description: (String) For the repositories matching, using doublestar pattern..
+                    description: (String) For the repositories matching. Use doublestar
+                      pattern for path matching.
                     type: string
                   tagExcluding:
-                    description: (String) For the tags excluding, using doublestar pattern.
+                    description: (String) For the tag excluding. Use doublestar pattern
+                      for path matching.
                     type: string
                   tagMatching:
-                    description: (String) For the tags matching, using doublestar pattern.
+                    description: (String) For the tag matching. Use doublestar pattern
+                      for path matching.
                     type: string
                 type: object
               conditions:

--- a/package/crds/project.harbor.crossplane.io_retentionpolicies.yaml
+++ b/package/crds/project.harbor.crossplane.io_retentionpolicies.yaml
@@ -95,16 +95,20 @@ spec:
                             the lasts n days.
                           type: number
                         repoExcluding:
-                          description: (String) For the repositories excluding, using doublestar pattern.
+                          description: (String) For the repositories excluding. Use
+                            doublestar pattern for path matching.
                           type: string
                         repoMatching:
-                          description: (String) For the repositories matching, using doublestar pattern..
+                          description: (String) For the repositories matching. Use
+                            doublestar pattern for path matching.
                           type: string
                         tagExcluding:
-                          description: (String) For the tags excluding, using doublestar pattern.
+                          description: (String) For the tag excluding. Use doublestar
+                            pattern for path matching.
                           type: string
                         tagMatching:
-                          description: (String) For the tags matching, using doublestar pattern.
+                          description: (String) For the tag matching. Use doublestar
+                            pattern for path matching.
                           type: string
                         untaggedArtifacts:
                           description: (Boolean) with untagged artifacts. Defaults
@@ -236,16 +240,20 @@ spec:
                             the lasts n days.
                           type: number
                         repoExcluding:
-                          description: (String) For the repositories excluding, using doublestar pattern.
+                          description: (String) For the repositories excluding. Use
+                            doublestar pattern for path matching.
                           type: string
                         repoMatching:
-                          description: (String) For the repositories matching, using doublestar pattern..
+                          description: (String) For the repositories matching. Use
+                            doublestar pattern for path matching.
                           type: string
                         tagExcluding:
-                          description: (String) For the tags excluding, using doublestar pattern.
+                          description: (String) For the tag excluding. Use doublestar
+                            pattern for path matching.
                           type: string
                         tagMatching:
-                          description: (String) For the tags matching, using doublestar pattern.
+                          description: (String) For the tag matching. Use doublestar
+                            pattern for path matching.
                           type: string
                         untaggedArtifacts:
                           description: (Boolean) with untagged artifacts. Defaults
@@ -461,16 +469,20 @@ spec:
                             the lasts n days.
                           type: number
                         repoExcluding:
-                          description: (String) For the repositories excluding, using doublestar pattern.
+                          description: (String) For the repositories excluding. Use
+                            doublestar pattern for path matching.
                           type: string
                         repoMatching:
-                          description: (String) For the repositories matching, using doublestar pattern..
+                          description: (String) For the repositories matching. Use
+                            doublestar pattern for path matching.
                           type: string
                         tagExcluding:
-                          description: (String) For the tags excluding, using doublestar pattern.
+                          description: (String) For the tag excluding. Use doublestar
+                            pattern for path matching.
                           type: string
                         tagMatching:
-                          description: (String) For the tags matching, using doublestar pattern.
+                          description: (String) For the tag matching. Use doublestar
+                            pattern for path matching.
                           type: string
                         untaggedArtifacts:
                           description: (Boolean) with untagged artifacts. Defaults

--- a/package/crds/project.harbor.crossplane.io_retentionpolicies.yaml
+++ b/package/crds/project.harbor.crossplane.io_retentionpolicies.yaml
@@ -95,16 +95,16 @@ spec:
                             the lasts n days.
                           type: number
                         repoExcluding:
-                          description: (String) For the repositories excluding.
+                          description: (String) For the repositories excluding, using doublestar pattern.
                           type: string
                         repoMatching:
-                          description: (String) For the repositories matching.
+                          description: (String) For the repositories matching, using doublestar pattern..
                           type: string
                         tagExcluding:
-                          description: (String) For the tag excluding.
+                          description: (String) For the tags excluding, using doublestar pattern.
                           type: string
                         tagMatching:
-                          description: (String) For the tag matching.
+                          description: (String) For the tags matching, using doublestar pattern.
                           type: string
                         untaggedArtifacts:
                           description: (Boolean) with untagged artifacts. Defaults
@@ -236,16 +236,16 @@ spec:
                             the lasts n days.
                           type: number
                         repoExcluding:
-                          description: (String) For the repositories excluding.
+                          description: (String) For the repositories excluding, using doublestar pattern.
                           type: string
                         repoMatching:
-                          description: (String) For the repositories matching.
+                          description: (String) For the repositories matching, using doublestar pattern..
                           type: string
                         tagExcluding:
-                          description: (String) For the tag excluding.
+                          description: (String) For the tags excluding, using doublestar pattern.
                           type: string
                         tagMatching:
-                          description: (String) For the tag matching.
+                          description: (String) For the tags matching, using doublestar pattern.
                           type: string
                         untaggedArtifacts:
                           description: (Boolean) with untagged artifacts. Defaults
@@ -461,16 +461,16 @@ spec:
                             the lasts n days.
                           type: number
                         repoExcluding:
-                          description: (String) For the repositories excluding.
+                          description: (String) For the repositories excluding, using doublestar pattern.
                           type: string
                         repoMatching:
-                          description: (String) For the repositories matching.
+                          description: (String) For the repositories matching, using doublestar pattern..
                           type: string
                         tagExcluding:
-                          description: (String) For the tag excluding.
+                          description: (String) For the tags excluding, using doublestar pattern.
                           type: string
                         tagMatching:
-                          description: (String) For the tag matching.
+                          description: (String) For the tags matching, using doublestar pattern.
                           type: string
                         untaggedArtifacts:
                           description: (Boolean) with untagged artifacts. Defaults


### PR DESCRIPTION
### Description of your changes

Clarify usage of doublestar pattern for string matching in docs.
Clarifies #29.

I know that you can derive that the doublestar pattern is being used from the [example](https://github.com/globallogicuki/provider-harbor/blob/08c780ae3a54b3e96fabae3d479a14c1417f6b38/examples/project/retentionpolicy.yaml#L17), but it's not clear if you just go by the docs how to define several elements. Would be cool to have this explicit in my opinion :)

Also: I changed `tag` to `tags`, as this is not clear from the singular that multiple tags can be defined here.

I have:

- [x ] Read and followed Crossplane's [contribution process].
- [x ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Not needed, just comments

[contribution process]: https://git.io/fj2m9
